### PR TITLE
Remove reference to GUNW products in overview of HyP3 directory struc…

### DIFF
--- a/docs/dir_structure.md
+++ b/docs/dir_structure.md
@@ -380,8 +380,8 @@ mintpy.load.waterMaskFile    = $DATA_DIR/SanFranSenDT42/mask/watermask.msk
 
 ### [ASF HyP3](https://hyp3-docs.asf.alaska.edu/)
 
-1. Search, request and download GUNW products using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb) or the [ASF Vertex website](https://search.asf.alaska.edu/) following the [story map](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3).
-    + For at least one GUNW product, download the accompanying DEM.
+1. Search, request and download interferograms using [hyp3_sdk](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb) or the [ASF Vertex website](https://search.asf.alaska.edu/) following the [story map](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3).
+    + For at least one interferogram, download the accompanying DEM.
     + Unzip the downloaded files. E.g., `for f in *.zip; do unzip $f; done` in bash.
 
 2. Clip DEM and all interferograms to the same area using hyp3lib/[cutGeotiffs.py](https://github.com/ASFHyP3/hyp3-lib/blob/develop/hyp3lib/cutGeotiffs.py) script.


### PR DESCRIPTION
…ture

Geocoded Unwrapped Interferogram (GUNW) products are generated by ARIA. The GUNW reference was inadvertently copied into in the HyP3 section when it was initially added in https://github.com/insarlab/MintPy/pull/542 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
